### PR TITLE
의존성 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^7.6.15",
+        "@nestjs/config": "^1.0.1",
         "@nestjs/core": "^7.6.15",
         "@nestjs/platform-express": "^7.6.15",
         "@nestjs/typeorm": "^8.0.2",
@@ -1627,6 +1628,32 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/config": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-1.0.1.tgz",
+      "integrity": "sha512-azMl4uYlFIhYsywFxPJT81RxF3Pnn0TZW3EEmr0Wa0Wex8R2xpvBNrCcrOgW3TB1xGMP7eqBrlfsVh5ZP82szg==",
+      "dependencies": {
+        "dotenv": "10.0.0",
+        "dotenv-expand": "5.1.0",
+        "lodash.get": "4.4.2",
+        "lodash.has": "4.5.2",
+        "lodash.set": "4.3.2",
+        "uuid": "8.3.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0",
+        "reflect-metadata": "^0.1.13",
+        "rxjs": "^6.0.0 || ^7.2.0"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@nestjs/core": {
@@ -4004,6 +4031,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -7092,11 +7124,26 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "node_modules/lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "node_modules/lodash.toarray": {
       "version": "4.4.0",
@@ -12750,6 +12797,26 @@
         "uuid": "8.3.2"
       }
     },
+    "@nestjs/config": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-1.0.1.tgz",
+      "integrity": "sha512-azMl4uYlFIhYsywFxPJT81RxF3Pnn0TZW3EEmr0Wa0Wex8R2xpvBNrCcrOgW3TB1xGMP7eqBrlfsVh5ZP82szg==",
+      "requires": {
+        "dotenv": "10.0.0",
+        "dotenv-expand": "5.1.0",
+        "lodash.get": "4.4.2",
+        "lodash.has": "4.5.2",
+        "lodash.set": "4.3.2",
+        "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        }
+      }
+    },
     "@nestjs/core": {
       "version": "7.6.18",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-7.6.18.tgz",
@@ -14555,6 +14622,11 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
       "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+    },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -16915,11 +16987,26 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.toarray": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^7.6.15",
+    "@nestjs/config": "^1.0.1",
     "@nestjs/core": "^7.6.15",
     "@nestjs/platform-express": "^7.6.15",
     "@nestjs/typeorm": "^8.0.2",


### PR DESCRIPTION
## 설치된 Package 📦
- `@nestjs/typeorm`
- `typeorm`
- `mysql2`

## Dependency Conflict로 인한 `@nestjs/common`의  package version 경고 안내 ⚠️

![스크린샷 2021-09-29 오후 9 09 03](https://user-images.githubusercontent.com/68471917/135283389-3720d466-41ab-4aaa-bec9-2d6210e39d14.png)

Error 메세지를 보게되면 `@nestjs/common@"^7.6.15"`이 현재 node_modules에 있는데,
`@nestjs/common@"^8.0.0"`를 사용해야만 `@nestjs/typeorm@8.0.2` package와 충돌이 일어나지 않는다고 합니다.

원래 `npm4~6`때는 **peer dependency conflict**가 일어나면 Warning을 띄우고, 무시하고 설치를 진행하였으나,
`npm7`부터는 Error를 내며 설치를 중지하게 됩니다.

그래서 저는 일단 **--legacy-peer-deps**로 이 충돌을 무시하고 요청을 보내기로 결정했습니다.
행여나 나중에 의존성과 관련된 Error가 일어나게 된다면 그 때 다시 이 PR을 Issue화 시키면 좋을 것 같습니다.

### 결과
<img width="368" alt="스크린샷 2021-09-29 오후 11 20 57" src="https://user-images.githubusercontent.com/68471917/135287581-3d9bee1e-e7f8-4d83-9789-1f0497cf2544.png">