### PR TITLE
:dizzy: (Entity) Entity renaming

### DIFF
--- a/src/entities/Answer.entity.ts
+++ b/src/entities/Answer.entity.ts
@@ -8,7 +8,7 @@ import {
 } from 'typeorm';
 
 @Entity('answer')
-export default class AnswerEntity extends BaseEntity {
+export default class Answer extends BaseEntity {
   @PrimaryGeneratedColumn()
   idx: number;
 

--- a/src/entities/AnswerPhoto.entity.ts
+++ b/src/entities/AnswerPhoto.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('answer_photo')
-export default class AnswerPhotoEntity {
+export default class AnswerPhoto {
   @PrimaryGeneratedColumn()
   idx: number;
 

--- a/src/entities/Question.entity.ts
+++ b/src/entities/Question.entity.ts
@@ -2,7 +2,7 @@ import { Column, Entity } from 'typeorm';
 import AnswerEntity from './Answer.entity';
 
 @Entity('question')
-export default class QuestionEntity extends AnswerEntity {
+export default class Question extends AnswerEntity {
   @Column({ nullable: false })
   title: string;
 }

--- a/src/entities/QuestionPhoto.entity.ts
+++ b/src/entities/QuestionPhoto.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('question_photo')
-export default class QuestionPhotoEntity {
+export default class QuestionPhoto {
   @PrimaryGeneratedColumn()
   idx: number;
 

--- a/src/entities/User.entity.ts
+++ b/src/entities/User.entity.ts
@@ -1,7 +1,7 @@
 import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('user')
-export default class UserEntity extends BaseEntity {
+export default class User extends BaseEntity {
   @PrimaryGeneratedColumn()
   idx: number;
 

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,12 +1,12 @@
-import UserEntity from './User.entity';
-import QuestionEntity from './Question.entity';
-import AnswerEntity from './Answer.entity';
-import QuestionPhotoEntity from './QuestionPhoto.entity';
-import AnswerPhotoEntity from './AnswerPhoto.entity';
+import User from './User.entity';
+import Question from './Question.entity';
+import Answer from './Answer.entity';
+import QuestionPhoto from './QuestionPhoto.entity';
+import AnswerPhoto from './AnswerPhoto.entity';
 export default [
-  UserEntity,
-  QuestionEntity,
-  AnswerEntity,
-  QuestionPhotoEntity,
-  AnswerPhotoEntity,
+  User,
+  Question,
+  Answer,
+  QuestionPhoto,
+  AnswerPhoto,
 ];


### PR DESCRIPTION
## 🌊 개요

Active Record pattern 사용의 용이성을 위해 Entity name 수정하였습니다!

## 🧑‍💻 작업사항

Entity의 이름만 남고 뒤에 'Entity'는 모두 삭제하였습니다

_(예시)_
Entity들의 이름이 `QuestionEntity` 에서 `Question`으로 변경되었습니다.

## 📸 스크린샷

![Sprint-entity](https://user-images.githubusercontent.com/68847615/139226772-c99659a9-618a-4d8f-8d0e-720166e1f9e8.png)
.
