### PR TITLE
:sparkles: (swagger) swagger UI에 'api' BasePath를 적용했습니다.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ async function bootstrap() {
     .setTitle('Sprint')
     .setDescription('Sprint 프로젝트를 위한 API 문서')
     .setVersion('1.0')
+    .setBasePath('api')
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);


### PR DESCRIPTION
## 🌊 개요

<img width="439" alt="스크린샷 2021-11-10 오후 2 09 20" src="https://user-images.githubusercontent.com/68471917/141053590-fdf9f621-fdea-4f9a-9538-b7715343517a.png">

Swagger UI에서 **`404 Error`** 가 나는 것을 BasePath를 추가함으로 Fix했습니다.

## 🧑‍💻 작업사항
**setBasePath**에 `'api'` 경로를 추가하였습니다.

## 📸 스크린샷
![스크린샷 2021-11-10 오후 1 44 03](https://user-images.githubusercontent.com/68471917/141051266-973c1a41-43de-4e37-b0d7-a0cd25006830.png)

