### PR TITLE
:bug: (main.ts) hoisting GlobalPrefix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,18 +9,18 @@ async function bootstrap() {
   const app: NestApplication = await NestFactory.create(AppModule);
   const port: number = parseInt(process.env.PORT, 10) || 8080;
   app.useGlobalPipes(new ValidationPipe());
+  app.setGlobalPrefix('api');
   const config = new DocumentBuilder()
     .setTitle('Sprint')
     .setDescription('Sprint 프로젝트를 위한 API 문서')
     .setVersion('1.0')
-    .setBasePath('api')
     .build();
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
-  app.setGlobalPrefix('api');
+  SwaggerModule.setup('docs', app, document);
 
   await app.listen(port);
-  Logger.log(`Server is running on http://localhost:${port}/api`, 'Bootstrap');
+  Logger.log(`Server is running on http://localhost:${port}`, 'Bootstrap');
+  Logger.log(`http://localhost:${port}/docs`, 'SwaggerUI');
 
   if (module.hot) {
     module.hot.accept();


### PR DESCRIPTION
## 🌊 개요

swagger ui에서 execute시 404가 뜨는 error를 해결
이유는 GlobalPrefix가 apply 되기 전에, Swagger Document를 build했기 때문에 BasePath에 **`'api'`** 가 없었다.

## 🧑‍💻 작업사항

- **app.setGlobalPrefix를 DocumentBuilder 위로 hoisting**
- **Logger 추가**
- **Swagger UI에 접근하는 경로를 `http://localhost:3000/docs`로 변경**


## 📸 스크린샷
<img width="1450" alt="스크린샷 2021-11-25 오후 8 44 49" src="https://user-images.githubusercontent.com/68471917/143435890-83351c60-79dc-43cf-a24a-4b68db92190a.png">

