### PR TITLE
Feature/swagger/header config

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,14 @@ async function bootstrap() {
     .setTitle('Sprint')
     .setDescription('Sprint 프로젝트를 위한 API 문서')
     .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'Token',
+      },
+      'accessToken',
+    )
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -9,22 +9,43 @@ import {
   Request,
 } from '@nestjs/common';
 import { RegisterDto } from './dto/register.dto';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { AuthService } from '../auth/auth.service';
 import { SignInDto } from './dto/sign-in.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { TokenDto } from '../auth/dto/token.dto';
+import { TokenDto } from '../token/dto/token.dto';
+import { TokenService } from '../token/token.service';
+import { LocalAuthGuard } from '../auth/guards/local-auth.guard';
+import { User } from '../common/decorators/user.decorator';
 
 @Controller('user')
 export class UserController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly tokenService: TokenService,
+  ) {}
 
   @ApiTags('SignUp')
   @ApiOperation({ summary: '회원가입' })
+  @ApiCreatedResponse({ description: '회원가입 성공' })
+  @ApiBadRequestResponse({ description: '이미 등록된 사용자입니다.' })
   @Post('signup')
   @HttpCode(HttpStatus.CREATED)
   async signUp(@Body() registerDto: RegisterDto) {
-    const data: TokenDto = await this.authService.register(registerDto);
+    await this.authService.register(registerDto);
+    const data: TokenDto = this.tokenService.createTokens(
+      registerDto.email,
+      registerDto.username,
+    );
     return {
       status: 200,
       message: '회원가입을 성공하였습니다.',
@@ -34,12 +55,18 @@ export class UserController {
 
   @ApiTags('Login')
   @ApiOperation({ summary: '로그인' })
+  @ApiBody({ type: SignInDto })
+  @ApiOkResponse({ description: '로그인 성공(토큰 발급)' })
+  @ApiUnauthorizedResponse({
+    description: `틀린 비밀번호, 혹은 등록되지 않은 이메일`,
+  })
   @Post('login')
   @HttpCode(HttpStatus.OK)
-  async login(@Body() body: SignInDto) {
-    const data: TokenDto = await this.authService.login(
-      body.email,
-      body.password,
+  @UseGuards(LocalAuthGuard)
+  async login(@User() user) {
+    const data: TokenDto = this.tokenService.createTokens(
+      user.email,
+      user.username,
     );
     return {
       status: 200,
@@ -48,6 +75,10 @@ export class UserController {
     };
   }
 
+  @ApiBearerAuth()
+  @ApiTags('Test')
+  @ApiOperation({ summary: 'profile' })
+  @ApiBearerAuth('accessToken')
   @UseGuards(JwtAuthGuard)
   @Get('profile')
   profile(@Request() req) {


### PR DESCRIPTION
## 🌊 개요

token authentication을 위해서 swagger에서 `Authorization Header`에 token을 담을 수 있게 하였습니다.

## 🧑‍💻 작업사항

- [x] DocumentBuilder에 Bearer Auth를 추가
- [x] User Controller Response 수정

## 📸 스크린샷

- **Login Response**
<img width="369" alt="스크린샷 2021-12-16 오후 10 46 02" src="https://user-images.githubusercontent.com/68471917/146383378-862ed083-ce66-4681-9d1f-14afc5986d44.png">

- **Register Response**
<img width="283" alt="스크린샷 2021-12-16 오후 10 46 39" src="https://user-images.githubusercontent.com/68471917/146383467-7476fea1-f851-489a-871f-ef8baa8efb66.png">

