### PR TITLE
:sparkles: (entity) entity column name config

### DIFF
--- a/src/entities/answer.entity.ts
+++ b/src/entities/answer.entity.ts
@@ -15,19 +15,19 @@ import AnswerPhoto from './answer-photo.entity';
 
 @Entity('answer')
 export default class Answer extends BaseEntity {
-  @PrimaryGeneratedColumn()
+  @PrimaryGeneratedColumn( { name: 'answer_idx'})
   idx: number;
 
-  @Column({ nullable: false })
+  @Column({ name: 'answer_contents', nullable: false })
   contents: string;
 
-  @Column({ nullable: false, default: 0 })
+  @Column({ name: 'answer_like', nullable: false, default: 0 })
   like: number;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @CreateDateColumn({ name: 'answer_created_at' })
   createdAt: Date;
 
-  @UpdateDateColumn({ name: 'updated_at' })
+  @UpdateDateColumn({ name: 'answer_updated_at' })
   updatedAt: Date;
 
   @ManyToOne(() => Question, (question) => question.answer, {

--- a/src/entities/category.entity.ts
+++ b/src/entities/category.entity.ts
@@ -12,7 +12,7 @@ export default class Category {
   @PrimaryGeneratedColumn()
   idx: number;
 
-  @Column({ nullable: false })
+  @Column({ name: 'category_name',nullable: false })
   name: string;
 
   @ManyToOne(() => Question, (question) => question.category, {

--- a/src/entities/question.entity.ts
+++ b/src/entities/question.entity.ts
@@ -16,22 +16,22 @@ import Category from './category.entity';
 
 @Entity('question')
 export default class Question extends BaseEntity {
-  @PrimaryGeneratedColumn()
+  @PrimaryGeneratedColumn({ name: 'question_idx'})
   idx: number;
 
-  @Column({ nullable: false })
+  @Column({ name: 'question_title',nullable: false })
   title: string;
 
-  @Column({ nullable: false })
+  @Column({  name: 'question_contents', nullable: false })
   contents: string;
 
-  @Column({ nullable: false, default: 0 })
+  @Column({  name: 'question_like', nullable: false, default: 0 })
   like: number;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @CreateDateColumn({ name: 'question_created_at' })
   createdAt: Date;
 
-  @UpdateDateColumn({ name: 'updated_at' })
+  @UpdateDateColumn({ name: 'question_updated_at' })
   updatedAt: Date;
 
   @ManyToOne(() => User, (user) => user.question, {

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -13,7 +13,7 @@ import Question from './question.entity';
 import Answer from './answer.entity';
 @Entity('user')
 export default class User extends BaseEntity {
-  @PrimaryGeneratedColumn()
+  @PrimaryGeneratedColumn({ name: 'user_idx',})
   idx: number;
 
   @Column({ nullable: false, unique: true })


### PR DESCRIPTION
## 🌊 개요

게시글 전체조회를 위해 쿼리문을 작성하여 테스트 하던 도중
 entity의 column name이 중복되거나 구분하기 힘든 것들이 많아
__가독성 향상__ 을 위해 entity의 column name을 설정했습니다.

## 🧑‍💻 작업사항

중복되거나 구분이 힘든 column의 name을 각각의 entity에 해당하는 name으로 설정해주었습니다

## 📸 스크린샷

![image](https://user-images.githubusercontent.com/68847615/146502186-e4bfa379-432a-4e91-8f23-06193900e63c.png)

![image](https://user-images.githubusercontent.com/68847615/146502264-2e254f82-d49e-4c20-8ea7-35d8a844da00.png)
